### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/sh0rch/m365proxy/security/code-scanning/6](https://github.com/sh0rch/m365proxy/security/code-scanning/6)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify `contents: read`, which is sufficient for the workflow's needs. This ensures that the workflow adheres to the principle of least privilege by restricting the `GITHUB_TOKEN` to read-only access to repository contents.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
